### PR TITLE
Polyfuns/alt

### DIFF
--- a/src/Flattener.sk
+++ b/src/Flattener.sk
@@ -177,7 +177,14 @@ mutable class .Flattener(mutable v: Int = 0, glob: VMap = Map::mcreate(), mutabl
   mutable fun file(f: File): File {
     this.glob.clear();
     this.!v = 0;
-    this.!funs = f.funs;
+
+    newFuns = mutable Vector<Function>[];
+    newFuns.extend(this.funs);
+    newFuns.extend(f.funs);
+    this.!funs = newFuns.chill(); // we need to preserve all the functions in all the modules
+    // even thought, this approach seems to be susceptible to bugs
+    // the order in which the modules are processed matters, but that order is not really
+    // the order of dependencies
 
     f.decls.each(d -> d match { | Decl(_, n, _) -> { this.glob.add(n, this.nextVar());}});
     v = mutable Vector<Expr>[];

--- a/src/Flattener.sk
+++ b/src/Flattener.sk
@@ -5,7 +5,7 @@ type Funs = Vector<Fun>;
 type Statements = Vector<Stmt>;
 
 value class Module(name: String, imports: Strings, globs: Int, funs: Funs) {}
-value class Fun(name: String, params: Int, isPolyVar: Bool, body: Code, locals: Int) {}
+value class Fun(name: String, params: Int, body: Code, locals: Int) {}
 value class Code(stmts: Statements) {}
 
 base class Stmt {
@@ -83,7 +83,7 @@ class .Translator() {
     e match { | Var(_, str) -> Register(str) | _ -> Register("ERROR") }
   }
 
-  fun function(f: Function): Fun { Fun(f.name, f.params.size(), f.polyArg.isSome(), Code(this.statement(f.body)), f.locals)  }
+  fun function(f: Function): Fun { Fun(f.name, f.params.size(), Code(this.statement(f.body)), f.locals)  }
 }
 
 mutable class .PrettyPrint2(mutable indent: Int = 0) {
@@ -112,7 +112,7 @@ mutable class .PrettyPrint2(mutable indent: Int = 0) {
   }
 
   mutable fun function(f: Fun): String {
-    params = `${f.params}${if (f.isPolyVar) " +1" else ""}`;
+    params = `${f.params}`;
     s = `(function ${f.name}(${params} | ${f.locals}`;
     !s = s + ") ";
     this.inc();
@@ -195,10 +195,49 @@ mutable class .Flattener(mutable v: Int = 0, glob: VMap = Map::mcreate(), mutabl
   mutable fun function(f: Function): Function {
     locals : VMap = Map::mcreate();
     this.!v = 0;
-    f.params.each(p -> locals.add(p, this.nextVar()));
-    _ = f.polyArg.map(str -> locals.add(str, this.nextVar()));
-    (es, e) = this.expression(f.body, locals);
-    Function(f.tok, f.name, f.params, f.polyArg, this.toBlock(f.tok, es, e), this.v)
+    
+    if (f.polyArg.isSome()) {
+      this.polyFunction(f)
+    } else {
+      f.params.each(p -> locals.add(p, this.nextVar()));
+      _ = f.polyArg.map(str -> locals.add(str, this.nextVar()));
+      (es, e) = this.expression(f.body, locals);
+      Function(f.tok, f.name, f.params, f.polyArg, this.toBlock(f.tok, es, e), this.v)
+    }
+  }
+
+  mutable fun polyFunction(f: Function): Function {
+    locals : VMap = Map::mcreate();
+    this.!v = 0; // just to show that it's done
+
+    origParamCnt = f.params.size();
+    if (f.polyArg.isSome()) { !origParamCnt = origParamCnt + 1; };
+
+    aname = this.nextVar();
+    argVar = Var(f.tok, aname);
+    locals.add(aname, aname);
+
+    // rewrite all the parameters into something like
+    // Decl(<original token>, <original name>, Call(<original token>, "at", Vector[<original name>, <position>]))
+    // this needs to become a part of the body of the function, so I need to prepend it before transformation
+
+    unlistParams
+      = f.params.mapWithIndex((pos, name) -> Decl(f.tok, name, Call(f.tok, "at", Vector<Expr>[argVar, ValInt(f.tok, pos)])));
+    // all of this will go into a body
+    // they "redefine" original parameters and we make up a new, singular parameter (inside `argVar`)
+
+    unlistRest = f.polyArg.map(str -> Vector<Expr>[Decl(f.tok, str, Call(f.tok, "drop", Vector<Expr>[ValInt(f.tok, f.params.size()), argVar]))]).default(Vector<Expr>[]);
+
+    body = mutable Vector<Expr>[];
+    body.extend(unlistParams);
+    body.extend(unlistRest);
+    body.push(f.body);
+
+    (es, e) = this.expression(Block(f.tok, body.chill()), locals);
+    
+    params = Vector<String>[aname]; // There's always just this one "arguments"
+
+    Function(f.tok, f.name, params, None(), this.toBlock(f.tok, es, e), this.v)
   }
 
   readonly fun arityOf(fname: String): Arity {
@@ -310,7 +349,7 @@ mutable class .Flattener(mutable v: Int = 0, glob: VMap = Map::mcreate(), mutabl
             ve.push(Decl(t, varname, Call(t, n, es2.chill())));
             (ve, Var(t,varname))
           }
-          | AtLeast(ordCnt) -> {
+          | AtLeast(_) -> {
             // that `ordCnt` must be smaller than `argsCnt`, but at this point it will
             // I will have to construct a new variable and store a list in it
             // that list will contain all the additional arguments (rest of `es`)
@@ -320,16 +359,21 @@ mutable class .Flattener(mutable v: Int = 0, glob: VMap = Map::mcreate(), mutabl
             // I then construct the call, it will be almost exactly what is above, but I will push one more argument to it
             // that will be the new variable with the list
 
-            ordinary = es.slice(0, ordCnt); // only first `n` arguments
-            ordinary.each(e -> {
-              (v2, e2) = this.expression(e, locals);
-              es2.push(e2);
-              ve.extend(v2.chill());
-            });
+            // we know that every polyvariadic function is translated into a function with a single parameter
+            // we therefore need to put all the arguments into a list and only pass that list into the call
 
-            rest = es.slice(ordCnt); // until the end
+            // TODO: there are no ordinary arguments, everything goes into a list together with the rest thing
+            // ordinary = es.slice(0, ordCnt); // only first `n` arguments
+            // ordinary.each(e -> {
+            //   (v2, e2) = this.expression(e, locals);
+            //   es2.push(e2);
+            //   ve.extend(v2.chill());
+            // });
+
+            // rest = es.slice(ordCnt); // until the end
             listvars = mutable MExprs[];
-            rest.each(e -> {
+            // all original arguments will be flattened and put into a list-value
+            es.each(e -> {
               (v2, e2) = this.expression(e, locals);
               listvars.push(e2);
               ve.extend(v2.chill());

--- a/src/Interpreter.sk
+++ b/src/Interpreter.sk
@@ -106,8 +106,7 @@ mutable class Linearize(mutable cntr: Int) {
   mutable fun function(f: Reader.Fun): Fun {
     !this.cntr = 0;
     b = f.body.stmts.map(s -> this.statement(s)).flatten();
-    maybeExtra = if (f.isPolyVar) 1 else 0;
-    Fun(f.name, f.params + maybeExtra, b, f.locals)
+    Fun(f.name, f.params, b, f.locals)
   }
 
   mutable fun expression(e: Reader.Exp): Expr {
@@ -212,18 +211,12 @@ mutable class Frame(globals: mutable Vals, locals: mutable Vals, mutable pc: Int
 
   // [###] This might fail at runtime
   mutable fun setLocal(r: Int, v: Val): void {
-    // print_string(`setLocal(r=${r}, v=${v})`);
-    // print_string(`this.locals.size = ${this.locals.size()}`);
-
     this.locals![r] = v;
   }
 
   // [###] This might fail at runtime
   readonly fun getGlobal(r: Int): Val {
-    // print_string(`get global 0`);
-    // print_string(`globals.size() = ${this.globals.size()} | r= ${r}`);
     ret = this.globals[r];
-    // print_string(`get global 1`);
     ret
   }
 
@@ -247,7 +240,6 @@ type GlobMap = Map<String, mutable Vals>;  // From module name to module global 
 // Example runner
 fun runProgram(modules: Modules): Result<Val, String> {
   eval = Interpreter::mcreate(modules);
-  print_string(`____________________`);
 	eval.call("main", mutable Vals[]);
 	eval.run();
 }
@@ -473,9 +465,6 @@ mutable class PrettyPrint(mutable indent: Int = 0) {
   }
 
   mutable fun toModule(m: Module): String {
-	   if (m.name == "StdLib") {
-		   return "";
-		 };
      s = `\e[4;31mmodule\e[0m ${m.name}\n`;
      if (m.funs.size() == 0) {
        !s = s + "\n";
@@ -621,6 +610,24 @@ fun callBuiltin2(args: readonly Vector<Val>): Result<Val, String> {
         | (valx, valy) -> Failure(`Type Error: '=' was applied to '${valx.toOut()}' and '${valy.toOut()}'`)
       }
     }
+    | ValString("at") -> {
+        (args[1], args[2]) match {
+          | (ValList(vals), ValInt(i)) -> {
+            if (vals.size() >= i) Success(vals[i])
+            else Failure(`Evaluation Error: 'at' was called on a too short list.`)
+          }
+          | (v, i) -> Failure(`Type Error: 'at' was called on '${v}'\nwhich is NOT a list OR the '${i}' is not a number.`)
+        }
+      }
+    | ValString("write!") -> {
+      (args[1], args[2]) match {
+        | (ValString(msg), val) -> {
+          print_string(`>  ${msg}${val.toOut()}`);
+          Success(NullVal())
+        }
+        | (_, _) -> Failure(`Type Error: 'write!' was called with a non-string first argument.`)
+      }
+    }
     | _ -> Failure(`Symbol Error: Uknown binary-builtin '${name.toOut()}'`)
   }
 }
@@ -629,14 +636,6 @@ fun callBuiltin1(args: readonly Vector<Val>): Result<Val, String> {
   name = args[0];
 
   name match {
-    | ValString("write!") -> {
-      args[1] match {
-        | val -> {
-          print_string(`>  ${val.toOut()}`);
-          Success(NullVal())
-        }
-      }
-    }
     | ValString("!") -> {
       args[1] match {
         | ValBool(b) -> Success(ValBool(! b))
@@ -653,14 +652,14 @@ fun callBuiltin1(args: readonly Vector<Val>): Result<Val, String> {
       }
     }
     | ValString("tail") -> {
-          args[1] match {
-            | ValList(vals) -> {
-              if (vals.size() > 0) Success(ValList(vals.slice(1)))
-              else Failure(`Evaluation Error: 'tail' was called on an empty list.`)
-            }
-            | v -> Failure(`Type Error: 'tail' was called on '${v}'\nwhich is NOT a list.`)
+        args[1] match {
+          | ValList(vals) -> {
+            if (vals.size() > 0) Success(ValList(vals.slice(1)))
+            else Failure(`Evaluation Error: 'tail' was called on an empty list.`)
           }
+          | v -> Failure(`Type Error: 'tail' was called on '${v}'\nwhich is NOT a list.`)
         }
+      }
     | _ -> Failure(`Symbol Error: Uknown binary-builtin '${name.toOut()}'`)
   }
 }

--- a/src/Interpreter.sk
+++ b/src/Interpreter.sk
@@ -290,9 +290,7 @@ mutable class .Interpreter(modules: Modules, globals: mutable GlobMap, stack: mu
   // calling a builtin might result in Failure
   // the initialization part of a normal call should be fine, we expect it to always work
   mutable fun call(fname: String, args: mutable Vals): void {
-    if (fname == "list") {
-      this.nativeReturn(ValList(args.chill()))
-    } else if (fname == "builtin_bin") {
+    if (fname == "builtin_bin") {
       callBuiltin2(args) match {
         | Success(val) -> this.nativeReturn(val)
         | Failure(msg) -> this.!failure = (true, msg);

--- a/src/Main.sk
+++ b/src/Main.sk
@@ -43,14 +43,11 @@ fun good(p: Vector<String>): void {
 	l = Interpreter.Linearize::mcreate();
 	linearized: Vector<Interpreter.Module> = translated.map(m -> l.mod(m));
 
-	print_string(`_____________________________\n\n`);
-
 	linearized.each(m -> {
 		pp = mutable Interpreter.PrettyPrint();
 		if (true || m.name != "StdLib") { print_string(pp.toModule(m)); };
 	});
 
-	// print_string("...... 0");
 	Interpreter.runProgram(linearized) match {
 		| Failure(msg) -> {
 			print_string(`RUNTIME ERROR: ${msg}`);

--- a/tests/good/9/main.sm
+++ b/tests/good/9/main.sm
@@ -7,31 +7,58 @@
 
 (functions (
 
-  (function polyvar (a b ...c)
+  (function snd (a b ...c)
+    b
+  )
+
+  (function rest (a b ...c)
     c
+  )
+
+  (function rec (n)
+    (begin
+      (write! "rec-n: " n)
+      (let x n)
+      (if (== n 0)
+          (set! x n)
+          (set! x (rec (- n 1))))
+      x
+    )
   )
 
   (function main ()
     (begin
-      (let a (list 0 1 0 1 0 1))
-      (write! "a:")
-      (write! a)
-      # (let b (polyvar 0 1 2 3 4 5))
-      # (write! "b:")
-      # (write! b)
-      # (let c (polyvar "a" "b" "c" "d"))
-      # (write! "c:")
-      # (write! c)
-      # (let d (head c))
-      # (write! "d:")
-      # (write! d)
+      (let aa (drop 0 "hello"))
 
-      # (let lst (list 23 24 25 26))
-      # (write! lst)
+      (write! "aa: " aa)
+
+      (let bb (snd 1 2 3 4 5))
+      (write! "bb: " bb)
       
-      # (write! ALIST)
-      # (let e (head (tail ALIST)))
-      # (write! e)
+      (let a (list 0 1 0 1 0 1))
+      (write! "a: " a)
+      
+      (let o (rec 3))
+      (write! "o: " o)
+      
+      (let a1 (list 0 1 0 1 0 1))
+      (write! "a1: " a1)
+      
+      (let b (snd 0 1 2 3 4 5))
+      (write! "b: " b)
+
+      (let c (rest "a" "b" "c" "d"))
+      (write! "c: " c)
+      
+      (let d (head c))
+      (write! "d[head of c]: " d)
+
+      (let lst (list 23 24 25 26))
+      (write! "lst: " lst)
+      
+      (write! "ALIST: " ALIST)
+      (let e (head (tail ALIST)))
+      (write! "e: " e)
       0
     )
   )

--- a/tests/good/9/main.sm
+++ b/tests/good/9/main.sm
@@ -28,8 +28,7 @@
 
   (function main ()
     (begin
-      (let aa (drop 0 "hello"))
-
+      (let aa (drop 0 "hello")) # just seeing if `drop` works for 0
       (write! "aa: " aa)
 
       (let bb (snd 1 2 3 4 5))

--- a/tests/stdlib.sm
+++ b/tests/stdlib.sm
@@ -2,6 +2,7 @@
 
 (vars ( 
   (let test 230) # I just wanted to test a global in a stdlib
+  (let testlist (list 1 2 3 4 5))
 ))
 
 (functions (

--- a/tests/stdlib.sm
+++ b/tests/stdlib.sm
@@ -7,7 +7,19 @@
 (functions (
   #define polyvariadic function for list construction
   # it is actually a special built-in
-  (function list (...arglist) 0)
+  (function list (...arglist) arglist)
+
+  (function at (lst i) ( builtin_bin "at" lst i ))
+
+  (function drop (n lst)
+    (begin
+      (let res 0)
+      (if (== n 0)
+          (set! res lst)
+          (set! res (drop (- n 1) (tail lst))))
+          res
+    )
+  )
 
   # define all the builtin_* as "built-in"
   (function builtin_bin (op x y) 0)
@@ -31,7 +43,6 @@
   (function ! (x) ( builtin_un "!" x ))
   (function && (x y) ( builtin_bin "&&" x y ))
   (function || (x y) ( builtin_bin "||" x y ))
-  (function == (x y) ( builtin_bin "==" x y ))
 
   # numeric ordering
   (function < (x y) ( builtin_bin "<" x y ))
@@ -39,7 +50,10 @@
   (function <= (x y) ( builtin_bin "<=" x y ))
   (function >= (x y) ( builtin_bin ">=" x y ))
 
+  # universal comparison
+  (function == (x y) ( builtin_bin "==" x y ))
+
   # IO
-  (function write! (x) ( builtin_un "write!" x ))
+  (function write! (msg x) ( builtin_bin "write!" msg x ))
   (function read! () ( builtin_nul "read!" ))
 ))


### PR DESCRIPTION
This implementation does something a bit different than the previous one.

When we have a polyvariadic function we translate it in `Flattener` into a function with a single argument.
We can call that argument `arguments` like in some other languages.

If such a function is ever called (with the right number of arguments), all of the arguments are put into a list and this list becomes the sole argument of that call.

All the ordinary functions are called as usual with no change at all.
This makes it possible to implement `list` like this `(function list (...lst) lst)`.

In the previous implementation `list` had to be a language primitive.

On the other hand, we now need to always have functions `drop` and `at`. The `at` is a primitive, `drop` can be defined in the `stdlib`.